### PR TITLE
fix: CS 4.6 breaking changes

### DIFF
--- a/sleep_python_bridge/striker.py
+++ b/sleep_python_bridge/striker.py
@@ -53,8 +53,8 @@ class CSConnector:
 			self.cs_pass = cs_pass
 		self.cs_port = cs_port
 		self.cs_directory = cs_directory
-		# NOTE: This is known to work for CS 4.0 and 4.1. This may change in future versions. Possibly look into leveraging CS's agg script (not included on Mac OS systems)
-		self.aggscriptcmd = "java -XX:ParallelGCThreads=4 -XX:+AggressiveHeap -XX:+UseParallelGC -classpath '{}/cobaltstrike.jar' aggressor.headless.Start".format(self.cs_directory)
+		# NOTE: Leverage agscript to ensure jar unpacked, and client jar called correctly (v4.6 change)
+		self.aggscriptcmd = "'{}/agscript'".format(self.cs_directory)
 		# This gets populated once the connect function is run (in the future, maybe run that function in the initialization?)
 		self.cs_process = None
 
@@ -443,7 +443,7 @@ class CSConnector:
 																			self.cs_host,
 																			self.cs_port,
 																			self.cs_user,
-																			self.cs_pass))
+																			self.cs_pass), cwd=self.cs_directory)
 
 		# check if process is alive
 		if not self.cs_process.isalive():


### PR DESCRIPTION
### Issue
The April 12th 2022 release of CS 4.6 introduced a couple of breaking changes relating to connecting to the teamserver. From the release notes:
- "The Cobalt Strike client now runs from a new jar file ('cobaltstrike-client.jar' rather than 'cobaltstrike.jar')."
- "The 'TeamServerImage' and 'cobaltstrike-client.jar' files are extracted from the 'cobaltstrike.jar' as needed."

With this change, using the bridge would result in errors attempting to make a connection to the teamserver due to the client jar being renamed to 'cobaltstrike-client.jar' (problematic line [here](https://github.com/Cobalt-Strike/sleep_python_bridge/blob/f9c25370deb093883210e9c6b5b151cb257079b7/sleep_python_bridge/striker.py#L57)).

Also, 'cobaltstrike-client.jar' is not extracted automatically on teamserver start up. This opens up a conditional where a CS server could be started/created while the bridge will fail to locate 'cobaltstrike-client.jar' (if called directly, which is why replacing 'cobaltstrike.jar' with 'cobaltstrike-client.jar' [here](https://github.com/Cobalt-Strike/sleep_python_bridge/blob/f9c25370deb093883210e9c6b5b151cb257079b7/sleep_python_bridge/striker.py#L57) is not a sufficient fix) due to client jar file not having been extracted yet. 

### Proposed Fix

Initiating the teamserver connection by calling agscript ensures that the client jar will always be extracted and launched appropriately. The additional 'cwd' argument passed to pexpect.spawn ensures successful jar extraction (due to relative links used to source helper files/functions).