### PR TITLE
Updates to the beaconlogtracker script

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ This will keep beaconlogs.json sync'd with saved and running beacon logs. It syn
 
 Start a webserver from output/html directory
 
-`python3 http.server`
+`python3 -m http.server 8000`
 
 Connect to http://localhost:8000/beaconlogs.html
 
@@ -207,6 +207,7 @@ This will create the beacons.json file used by the javascript grapher.
 
 Start a webserver from output/html directory
 
-`python3 http.server`
+`python3 -m http.server 8000`
 
 Connect to http://localhost:8000/beacons.html
+

--- a/beaconlogtracker.py
+++ b/beaconlogtracker.py
@@ -52,8 +52,15 @@ def main(args):
         cs_pass=cs_pass,
         cs_directory=cs_directory)
     
-    print(f"[*] Connecting to teamserver: {cs_host}")
-    cs.connectTeamserver()
+    while(1):
+        print(f"[*] Connecting to teamserver: {cs_host}")
+        try:
+           cs.connectTeamserver()
+           break
+        except:
+            print(f"[!] Unable to connect to the teamserver, is it running? Waiting {sleeptime} seconds to try again.")
+            time.sleep(sleeptime)
+            continue
 
     while(1):
         print("[Beacon Log Tracker] Getting beacon logs from teamserver...")
@@ -69,8 +76,9 @@ def main(args):
         # JSON field reference: type, beacon_id, user, command, result, timestamp
 
         if beaconlogresult is None:
-            print("[!] No logs yet. Did you just start the teamserver?")
-            exit()
+            print(f"[!] No logs yet. Waiting {sleeptime} seconds for a beacon to check in.")
+            time.sleep(sleeptime)
+            continue
 
         for log in beaconlogresult:
 
@@ -188,3 +196,4 @@ if __name__ == "__main__":
 
     args = parseArguments()
     main(args)
+


### PR DESCRIPTION
Made some minor updates to the beaconlogtracker python script.
1. Updated README.md file to add the -m option when starting a web server with python.
2. Updated beaconlogtracker script on startup to continually try to connect to the teamserver every 30 seconds if a connection could not be made.
3. Updated beaconlogtracker script if the beaconlogs data is empty to not exit and instead try again in 30 seconds.  A beacon needs to actually check in to the teamserver for the logs to be available.