### PR TITLE
Add conditional sys_platform requirement to python-magic-bin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-magic>=0.4.18
 libmagic>=1.0
-python-magic-bin>=0.4.14
+python-magic-bin>=0.4.14; sys_platform=="win32"
 javaobj-py3>=0.4.1
 pepy>=1.2.0
 ptyprocess>=0.5


### PR DESCRIPTION
The python-magic-bin package is not required or (installable) under linux.