### PR TITLE
Extended payloadgenerator.py

### DIFF
--- a/payloadgenerator.py
+++ b/payloadgenerator.py
@@ -22,14 +22,27 @@ payloadPath = "output/payloads/"
 ####################
 ## FUNCTIONS
 def parseArguments():
+    global payloadPath
+
     parser = ArgumentParser()
     parser.add_argument('host', help='The teamserver host.')
     parser.add_argument('port', help='The teamserver port.')
     parser.add_argument('username', help='The desired username.')
     parser.add_argument('password', help='The teamserver password.')
     parser.add_argument('path', help="Directory to CobaltStrike")
-    
+
+    opt = parser.add_argument_group('optional parameters')
+    opt.add_argument('-o', '--payload-path', metavar='path', default=payloadPath, help=f"Where to save generated payloads. Default: {payloadPath}")
+    opt.add_argument('-l', '--listener', metavar='name', default='all', help=f"Specify listener name to get payloads for. Default: payloads for all listeners will be produced")
+    opt.add_argument('-a', '--arch', metavar='arch', default='both', choices=['both', 'x64', 'x86'], help=f"Specify payload architecture. Choices: x86, x64. Default: payloads for both are generated")
+    opt.add_argument('-t', '--payload-types', metavar='types', default='exe,dll,bin', help=f"Comma separated list of payload types to generate keyed by file extensions. Choices: exe,dll,svc.exe,bin,ps1,py,vbs or use 'all' to compile all at once. Default: exe,dll,bin")
+    opt.add_argument('-e', '--exit', metavar='exit', choices=['thread', 'process'], default='process', help=f"Payload exit method. Choices: thread, process. Default: process")
+    opt.add_argument('-c', '--call-method', metavar='method', choices=['direct', 'indirect', 'none', ''], default='', help=f"Payload exit method. Choices: indirect, direct, none. Default: <empty> (backwards compatible with Cobalt pre 4.8)")
+
     args = parser.parse_args()
+
+    payloadPath = args.payload_path
+
     return args
 
 
@@ -46,6 +59,17 @@ def main(args):
     cs_user = args.username
     cs_pass = args.password
     cs_directory = args.path
+    cs_listener = args.listener
+    cs_exit = args.exit
+    cs_callmethod = args.call_method.capitalize()
+    cs_types = args.payload_types
+    cs_architectures = [args.arch, ]
+
+    if cs_callmethod == '':
+        cs_exit = ''
+
+    if args.arch == 'both':
+        cs_architectures = ['x86', 'x64']
 
     ####################
     ## Connect to server
@@ -67,26 +91,33 @@ def main(args):
         time.sleep(3) # Allow time for the script to load
         print(f"[*] Loaded {script_name} kit with ag_load_script")
 
+        payloadTypes = {
+            'dll' : ArtifactType.DLL,
+            'exe' : ArtifactType.EXE,
+            'svc.exe' : ArtifactType.SVCEXE,
+            'bin' : ArtifactType.RAW,
+            'ps1' : ArtifactType.POWERSHELL,
+            'py' : ArtifactType.PYTHON,
+            'vbs' : ArtifactType.VBSCRIPT,
+        }
+
+        if cs_types == 'all':
+            cs_types = ','.join(payloadTypes.keys())
+
+        payloads = [x for x in cs_types.split(',') if x in payloadTypes]
+
         for listener in listeners:
-            print(f"[*] Creating payloads for listener: {listener}")
+            if cs_listener != 'all' and listener.lower() != cs_listener.lower():
+                continue
 
-            # x64 dll
-            payloadName = f"{listener}.x64.dll"
-            print(f"[*] Creating {payloadName}")
-            payloadBytes = cs.generatePayload(listener,ArtifactType.DLL,False,True)
-            write_payload(payloadPath,payloadName,payloadBytes,hostPayload)
+            print(f"[*] Creating stageless payloads for listener: {listener}")
 
-            # x64 exe
-            payloadName = f"{listener}.x64.exe"
-            print(f"[*] Creating {payloadName}")
-            payloadBytes = cs.generatePayload(listener,ArtifactType.EXE,False,True)
-            write_payload(payloadPath,payloadName,payloadBytes,hostPayload)
-
-            # x64 bin
-            payloadName = f"{listener}.x64.bin"
-            print(f"[*] Creating {payloadName}")
-            payloadBytes = cs.generatePayload(listener,ArtifactType.RAW,False,True)
-            write_payload(payloadPath,payloadName,payloadBytes,hostPayload)
+            for arch in cs_architectures:
+                for k in payloads:
+                    payloadName = f'{listener}.{arch}.{k}'
+                    print(f"[*] Creating {payloadName}")
+                    payloadBytes = cs.generatePayload(listener, payloadTypes[k], False, arch == 'x64', cs_exit, cs_callmethod)
+                    write_payload(payloadPath, payloadName, payloadBytes, hostPayload)
 
     #########
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-magic-bin>=0.4.14; sys_platform=="win32"
 javaobj-py3>=0.4.1
 pepy>=1.2.0
 ptyprocess>=0.5
+pexpect

--- a/sleep_python_bridge/striker.py
+++ b/sleep_python_bridge/striker.py
@@ -140,7 +140,9 @@ class CSConnector:
 		listener: str, 
 		artifact_type: 'ArtifactType', 
 		staged: bool = False, 
-		x64: bool = True
+		x64: bool = True,
+		exit: str = '',
+		callmethod : str = ''
 	) -> bytes:
 		"""Geneartes a Cobalt Strike payload and returns the bytes.
 
@@ -160,10 +162,13 @@ class CSConnector:
 
 		if staged:
 			function = "artifact_stager"
+			cmd = f"return base64_encode(artifact_stager('{listener}', '{artifact_type.value}', '{arch}'))"
 		else:
-			function = "artifact_payload"
+			if len(callmethod) > 0 and len(exit) > 0:
+				cmd = f"return base64_encode(artifact_payload('{listener}', '{artifact_type.value}', '{arch}', '{exit}', '{callmethod}'))"
+			else:
+				cmd = f"return base64_encode(artifact_payload('{listener}', '{artifact_type.value}', '{arch}'))"
 
-		cmd = f"return base64_encode({function}('{listener}', '{artifact_type.value}', '{arch}'))"
 		encoded_bytes = self.ag_get_object(cmd, timeout=30000)
 		# We converted the bytes to b64 for transferring, so now convert them back
 		return base64.b64decode(encoded_bytes)


### PR DESCRIPTION
Hi guys! :)

I just extended `payloadgenerator.py` with additional arguments and added support for CS 4.8 `artifact_payload` function parameters.

Now we have more control over what's going to be generated.

### Usage

```
------------------------
Beacon Payload Generator
------------------------
usage: payloadgenerator.py [-h] [-o path] [-l name] [-a arch] [-t types] [-e exit] [-c method] host port username password path

positional arguments:
  host                  The teamserver host.
  port                  The teamserver port.
  username              The desired username.
  password              The teamserver password.
  path                  Directory to CobaltStrike

options:
  -h, --help            show this help message and exit

optional parameters:
  -o path, --payload-path path
                        Where to save generated payloads. Default: output/payloads/
  -l name, --listener name
                        Specify listener name to get payloads for. Default: payloads for all listeners will be produced
  -a arch, --arch arch  Specify payload architecture. Choices: x86, x64. Default: payloads for both are generated
  -t types, --payload-types types
                        Comma separated list of payload types to generate keyed by file extensions. Choices: exe,dll,svc.exe,bin,ps1,py,vbs or use 'all' to compile all at once. Default: exe,dll,bin
  -e exit, --exit exit  Payload exit method. Choices: thread, process. Default: process
  -c method, --call-method method
                        Payload exit method. Choices: indirect, direct, none. Default: <empty> (backwards compatible with Cobalt pre 4.8)
```

### Examples

```
kali # python3 payloadgenerator.py 127.0.0.1 50050 bot password /path/to/cobalt -o /share/payloads/ -c indirect -a x64
------------------------
Beacon Payload Generator
------------------------
[*] Connecting to teamserver: 127.0.0.1
[*] Loaded payload_scripts.cna kit with ag_load_script
[*] Creating stageless payloads for listener: http1
[*] Creating http1.x64.exe
[*] Creating http1.x64.dll
[*] Creating http1.x64.bin

kali  # python3 payloadgenerator.py 127.0.0.1 50050 bot password /path/to/cobalt -o /share/payloads/ -c indirect -a x64 -t exe
------------------------
Beacon Payload Generator
------------------------
[*] Connecting to teamserver: 127.0.0.1
[*] Loaded payload_scripts.cna kit with ag_load_script
[*] Creating stageless payloads for listener: http1
[*] Creating http1.x64.exe

kali  # python3 payloadgenerator.py 127.0.0.1 50050 bot password /path/to/cobalt -o /share/payloads/
------------------------
Beacon Payload Generator
------------------------
[*] Connecting to teamserver: 127.0.0.1
[*] Loaded payload_scripts.cna kit with ag_load_script
[*] Creating stageless payloads for listener: http1
[*] Creating http1.x86.exe
[*] Creating http1.x86.dll
[*] Creating http1.x86.bin
[*] Creating http1.x64.exe
[*] Creating http1.x64.dll
[*] Creating http1.x64.bin
```

Hope you'll like it! :)

Cheers,
Mariusz